### PR TITLE
regex module not found

### DIFF
--- a/myanmar/encodings.py
+++ b/myanmar/encodings.py
@@ -1,5 +1,5 @@
 import json
-import regex as re
+import re
 import os
 
 class BaseEncoding ():


### PR DESCRIPTION
A fix for 

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/bin/myanmar-converter", line 9, in <module>
    load_entry_point('python-myanmar==0.0.1', 'console_scripts', 'myanmar-converter')()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/python_myanmar-0.0.1-py3.5.egg/myanmar/_private.py", line 11, in <module>
    import myanmar.converter
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/python_myanmar-0.0.1-py3.5.egg/myanmar/converter.py", line 6, in <module>
    from myanmar.language import *
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/python_myanmar-0.0.1-py3.5.egg/myanmar/language.py", line 7, in <module>
    'encodings.py'))
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/imp.py", line 170, in load_source
    module = _exec(spec, sys.modules[name])
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/python_myanmar-0.0.1-py3.5.egg/myanmar/encodings.py", line 2, in <module>
    import regex as re
ImportError: No module named 'regex'
```
